### PR TITLE
LaTeX patches

### DIFF
--- a/docweb/rst.py
+++ b/docweb/rst.py
@@ -289,6 +289,7 @@ docutils.parsers.rst.directives.register_directive('index', index_directive)
 import rst_latex
 rst_latex.OUT_PATH = settings.MATH_ROOT
 rst_latex.OUT_URI_BASE = settings.MATH_URL
+rst_latex.LATEX_PROLOGUE = settings.LATEX_PROLOGUE
 
 #------------------------------------------------------------------------------
 # Sphinx

--- a/docweb/rst_latex.py
+++ b/docweb/rst_latex.py
@@ -13,8 +13,7 @@ OUT_PATH = "/var/www-pub/root/pTSc0V/testwiki/math"
 OUT_URI_BASE = "http://192.168.0.100/pTSc0V/testwiki/math/"
 
 DVIPNG = "dvipng"
-LIMITED_LATEX = os.path.join(os.path.abspath(os.path.dirname(__file__)),
-                             "../scripts/limited-latex.py")
+LIMITED_LATEX = "latex"
 LATEX_TEMPLATE = r"""
 \documentclass[10pt]{article}
 \pagestyle{empty}

--- a/docweb/rst_latex.py
+++ b/docweb/rst_latex.py
@@ -24,6 +24,7 @@ LATEX_TEMPLATE = r"""
 %(raw)s
 \end{document}
 """
+LATEX_PROLOGUE = r""
 LATEX_ARGS = ["--interaction=nonstopmode"]
 DVIPNG_ARGS = ["-bgTransparent", "-Ttight", "--noghostscript", "-l1",
                ]
@@ -135,7 +136,8 @@ def latex_to_uri(in_text, with_baseline=False):
     file_name = os.path.join(OUT_PATH, file_basename)
     baseline_file_name = file_name + '.baseline'
     if not os.path.isfile(file_name):
-        baseline_offset = latex_to_png("", in_text, file_name, with_baseline)
+        baseline_offset = latex_to_png(LATEX_PROLOGUE, in_text, file_name,
+                                       with_baseline)
         if with_baseline:
             f = open(baseline_file_name, 'w')
             f.write(str(baseline_offset))

--- a/settings.py
+++ b/settings.py
@@ -177,6 +177,12 @@ SITE_ID = 1
 # to load the internationalization machinery.
 USE_I18N = True
 
+# LaTeX options
+# -------------
+#
+# Define custom commands and load additional packages for the LaTeX preamble.
+LATEX_PROLOGUE = r"""
+"""
 
 #------------------------------------------------------------------------------
 # Internal Django settings


### PR DESCRIPTION
Hi

I made the following changes:
- The link scripts/limited-latex.py is dead, and I couldn't figure out what it should have referred to originally, so I just invoke latex directly. You might want to change that...
- Added a new configuration variable LATEX_PROLOGUE which is passed to the `latex_to_png` function, enabling the definition of custom commands or the loading of extra packages. E.g. I load the sphinx `conf.py` from the `settings.py` file and extract the `latex_elements['preamble']` configuration entry in order to be consistent and avoid duplication.

Michael
